### PR TITLE
ToDoListApp module now at the correct level of abstraction

### DIFF
--- a/lib/todo/command_handler.ex
+++ b/lib/todo/command_handler.ex
@@ -1,6 +1,31 @@
 defmodule ToDo.CommandHandler do
   @unrecognized_message  "Sorry, I don't recognize that command."
 
+  def option_to_command("a") do
+   :add
+  end
+
+  def option_to_command("b") do
+   :list_tasks
+  end
+
+  def option_to_command("c" <> rest) do
+   {:edit, String.strip(rest)}
+  end
+
+  def option_to_command("d" <> rest) do
+   {:delete, String.strip(rest)}
+  end
+
+  def option_to_command("e") do
+   :exit
+  end
+
+  def option_to_command(_) do
+    ToDo.ConsoleDisplay.invalid_option
+    :invalid
+  end
+
   def action_command({:exit}, _) do
     {:exit}
   end
@@ -21,8 +46,16 @@ defmodule ToDo.CommandHandler do
     ToDo.DeleteTaskCommand.delete_task(task_number, previous_state)
   end
 
-
   def action_command({_}, _) do
     @unrecognized_message
+  end
+
+  def isolate_task_number_from_request(request, tasks) do
+    number_of_tasks =  tuple_size(List.to_tuple(tasks))
+    case Integer.parse(request) do
+      {number, ""} when number in 1..number_of_tasks -> number - 1
+      {number, _} -> tasks
+      :error -> tasks
+    end
   end
 end

--- a/lib/todo/console_display.ex
+++ b/lib/todo/console_display.ex
@@ -1,16 +1,47 @@
 defmodule ToDo.ConsoleDisplay do
+  @goodbye_message "Thanks for playing! Tasks are NOT persisted!"
+  @new_task_message "New Task: "
+  @amend_message "Amend task > "
+  @invalid_message "Invalid Option Entered"
+  @enter_any_key_message "Enter any key for menu options"
   @prompt "> "
 
   def display_to_do_list_and_cheatsheet(tasks) do
-    display_put(ToDo.TasksFormatter.tasks_for_display(tasks) <> ToDo.MenuOptionsFormatter.menu_options_for_display)
+    ToDo.TasksFormatter.tasks_for_display(tasks) <> ToDo.MenuOptionsFormatter.menu_options_for_display
+    |> display_put
   end
 
   def prompt_for_command do
-    String.downcase(String.strip(display_get(@prompt)))
+    String.downcase(display_get(@prompt))
+    |> ToDo.CommandHandler.option_to_command
+  end
+
+  def prompt_for_any_key do
+    display_get(@enter_any_key_message)
+  end
+
+  def invalid_option do
+    display_put("#{@invalid_message}")
+  end
+
+  def display_tasks(tasks_for_display) do
+    display_put(tasks_for_display)
+  end
+
+  def get_new_task do
+    display_get(@new_task_message)
+  end
+
+  def get_amended_text do
+    display_get("#{@amend_message}")
+  end
+
+  def say_goodbye do
+    display_put(@goodbye_message)
   end
 
   def display_get(message) do
-    IO.gets(message)
+    String.strip(IO.gets(message))
   end
 
   def display_put(message) do

--- a/lib/todo/todo_list_app.ex
+++ b/lib/todo/todo_list_app.ex
@@ -1,25 +1,23 @@
 defmodule ToDo.ToDoListApp do
-  @goodbye_message "Thanks for playing! Tasks are NOT persisted!"
-  @new_task_message "New Task: "
-  @amend_message "Amend task > "
-  @invalid_message "Invalid Option Entered"
-  @enter_any_key_message "Enter any key for menu options"
 
-  def options({:exit}) do
-    ToDo.ConsoleDisplay.display_put(@goodbye_message)
+  def run({:exit}) do
+    ToDo.ConsoleDisplay.say_goodbye
   end
 
-  def options({:list_tasks, tasks}) do
-    ToDo.ConsoleDisplay.display_get(@enter_any_key_message)
-    options(tasks)
+  def run({:list_tasks, tasks}) do
+    ToDo.ConsoleDisplay.prompt_for_any_key
+    run(tasks)
   end
 
-  def options(tasks) do
+  def run(tasks) do
     ToDo.ConsoleDisplay.display_to_do_list_and_cheatsheet(tasks)
     ToDo.ConsoleDisplay.prompt_for_command
-    |> option_to_command(tasks)
     |> process_command(tasks)
-    |> options
+    |> run
+  end
+
+  def process_command(:invalid, tasks) do
+    tasks
   end
 
   def process_command(:exit, _) do
@@ -28,12 +26,12 @@ defmodule ToDo.ToDoListApp do
 
   def process_command(:list_tasks, tasks) do
     ToDo.CommandHandler.action_command({:list_tasks}, tasks)
-    |> ToDo.ConsoleDisplay.display_put
+    |> ToDo.ConsoleDisplay.display_tasks
     {:list_tasks, tasks}
   end
 
   def process_command({:edit, task_number}, tasks) do
-    amended_text = String.strip(ToDo.ConsoleDisplay.display_get("#{@amend_message}"))
+    amended_text = ToDo.ConsoleDisplay.get_amended_text
     ToDo.CommandHandler.action_command({:edit, task_number, amended_text}, tasks)
   end
 
@@ -46,7 +44,7 @@ defmodule ToDo.ToDoListApp do
   end
 
   def get_new_tasks(tasks, :add) do
-    new_task = String.strip(ToDo.ConsoleDisplay.display_get(@new_task_message))
+    new_task = ToDo.ConsoleDisplay.get_new_task
     process_new_task({:add, new_task}, tasks)
   end
 
@@ -57,30 +55,5 @@ defmodule ToDo.ToDoListApp do
   def process_new_task(new_task, tasks) do
     ToDo.CommandHandler.action_command(new_task, tasks)
     |> get_new_tasks(:add)
-  end
-
-  def option_to_command("a", _) do
-   :add
-  end
-
-  def option_to_command("b", _) do
-   :list_tasks
-  end
-
-  def option_to_command("c" <> rest, _) do
-   {:edit, String.strip(rest)}
-  end
-
-  def option_to_command("d" <> rest, _) do
-   {:delete, String.strip(rest)}
-  end
-
-  def option_to_command("e", _) do
-   :exit
-  end
-
-  def option_to_command(_, tasks) do
-    ToDo.ConsoleDisplay.display_put("#{@invalid_message}")
-    options(tasks)
   end
 end

--- a/test/console_display_test.exs
+++ b/test/console_display_test.exs
@@ -3,32 +3,94 @@ defmodule ConsoleDisplayTest do
   import ExUnit.CaptureIO
   doctest ToDo
 
-  test "display contains the 'To Do List' heading" do
-    result = capture_io fn ->
-      ToDo.ConsoleDisplay.display_to_do_list_and_cheatsheet([])
+  defmodule IOAssert do
+    def assert_with_input(input, action_fn) do
+     capture_io([input: input], fn ->
+       action_fn.()
+     end)
     end
-    assert String.contains?(result, "To Do List")
+
+    def stdout_assert(action_fn, assert_fn) do
+     capture_io(fn ->
+       action_fn.()
+     end)
+     |> assert_fn.()
+    end
+  end
+
+  defmodule CommandHandler do
+    def option_to_command(option, expected) do
+      fn ->
+        assert ToDo.CommandHandler.option_to_command(option) == expected
+      end
+    end
+  end
+
+  test "display contains the 'To Do List' heading" do
+    action_fn = fn -> ToDo.ConsoleDisplay.display_to_do_list_and_cheatsheet([]) end
+    assert_fn = fn(result) -> assert String.contains?(result, "To Do List") end
+    IOAssert.stdout_assert(action_fn, assert_fn)
   end
 
   test "display contains 'Commands Cheatsheet' heading" do
-    result = capture_io fn ->
-      assert ToDo.ConsoleDisplay.display_to_do_list_and_cheatsheet([])
-    end
-    assert String.contains?(result, "Commands Cheatsheet")
+    action_fn = fn -> ToDo.ConsoleDisplay.display_to_do_list_and_cheatsheet([]) end
+    assert_fn = fn(result) -> assert String.contains?(result, "Commands Cheatsheet") end
+    IOAssert.stdout_assert(action_fn, assert_fn)
   end
 
   test "display contains a task in the 'To-Do list'" do
     todo_tasks = ["Go to yoga tonight"]
-    result = capture_io fn ->
-      ToDo.ConsoleDisplay.display_to_do_list_and_cheatsheet(todo_tasks)
-    end
-    assert String.contains?(result, "[1] #{todo_tasks}\n")
+    action_fn = fn(tasks) -> fn -> ToDo.ConsoleDisplay.display_to_do_list_and_cheatsheet(tasks) end end
+    assert_fn = fn(result) -> assert String.contains?(result, "[1] #{todo_tasks}\n") end
+    IOAssert.stdout_assert(action_fn.(todo_tasks), assert_fn)
+  end
+
+  test "invalid menu option is ignored" do
+   user_input = "e"
+   option = "9"
+   expected = :invalid
+   IOAssert.assert_with_input(user_input, CommandHandler.option_to_command(option, expected))
+  end
+
+  test "'a' menu option is valid" do
+    user_input = ""
+    option = "a"
+    expected = :add
+    IOAssert.assert_with_input(user_input, CommandHandler.option_to_command(option, expected))
+  end
+
+  test "'b' menu option is valid" do
+    user_input = ""
+    option = "b"
+    expected = :list_tasks
+    IOAssert.assert_with_input(user_input, CommandHandler.option_to_command(option, expected))
+  end
+
+  test "'c' menu option is valid" do
+    user_input = ""
+    option = "c 1"
+    expected = {:edit, "1"}
+    IOAssert.assert_with_input(user_input, CommandHandler.option_to_command(option, expected))
+  end
+
+  test "'d' menu option is valid" do
+    user_input = ""
+    option = "d 1"
+    expected = {:delete, "1"}
+    IOAssert.assert_with_input(user_input, CommandHandler.option_to_command(option, expected))
+  end
+
+  test "'e' menu option is valid" do
+    user_input = ""
+    option = "e"
+    expected = :exit
+    IOAssert.assert_with_input(user_input, CommandHandler.option_to_command(option, expected))
   end
 
   test "input received from prompt" do
     user_input = "a"
-    capture_io([input: user_input, capture_prompt: false], fn ->
-      assert ToDo.ConsoleDisplay.prompt_for_command == user_input
-    end)
+    expected = :add
+    prompt_for_command = fn(expected) -> fn -> assert ToDo.ConsoleDisplay.prompt_for_command == expected end end
+    IOAssert.assert_with_input(user_input, prompt_for_command.(expected))
   end
 end

--- a/test/todo_list_app_test.exs
+++ b/test/todo_list_app_test.exs
@@ -12,28 +12,16 @@ defmodule ToDoListAppTest do
   end
 
   defmodule ToDoListAppAssert do
-    def option_to_command(option, tasks, expected) do
-      fn ->
-        assert ToDo.ToDoListApp.option_to_command(option, tasks) == expected
-      end
-    end
-
     def add_new_tasks(tasks, expected_result) do
-      fn ->
-        assert ToDo.ToDoListApp.get_new_tasks(tasks, :add) == expected_result
-      end
+      fn -> assert ToDo.ToDoListApp.get_new_tasks(tasks, :add) == expected_result end
     end
 
     def process_command(command, tasks, expected_result) do
-      fn ->
-        assert ToDo.ToDoListApp.process_command(command, tasks) == expected_result
-      end
+      fn -> assert ToDo.ToDoListApp.process_command(command, tasks) == expected_result end
     end
 
-    def options(tasks, expected_result) do
-      fn ->
-        assert ToDo.ToDoListApp.options(tasks) == expected_result
-      end
+    def run(tasks, expected_result) do
+      fn -> assert ToDo.ToDoListApp.run(tasks) == expected_result end
     end
   end
 
@@ -43,54 +31,6 @@ defmodule ToDoListAppTest do
     task3 = "Get party hats"
     task_list = [task1, task2, task3]
     {:ok, task1: task1, task2: task2, task3: task3, tasks: task_list}
-  end
-
-  test "invalid menu option is ignored" do
-   user_input = "e"
-   option = "9"
-   tasks = []
-   expected = :ok
-   IOAssert.assert_with_input(user_input, ToDoListAppAssert.option_to_command(option, tasks, expected))
-  end
-
-  test "'a' menu option is valid" do
-    user_input = ""
-    option = "a"
-    tasks = []
-    expected = :add
-    IOAssert.assert_with_input(user_input, ToDoListAppAssert.option_to_command(option, tasks, expected))
-  end
-
-  test "'b' menu option is valid" do
-    user_input = ""
-    option = "b"
-    tasks = []
-    expected = :list_tasks
-    IOAssert.assert_with_input(user_input, ToDoListAppAssert.option_to_command(option, tasks, expected))
-  end
-
-  test "'c' menu option is valid" do
-    user_input = ""
-    option = "c 1"
-    tasks = []
-    expected = {:edit, "1"}
-    IOAssert.assert_with_input(user_input, ToDoListAppAssert.option_to_command(option, tasks, expected))
-  end
-
-  test "'d' menu option is valid" do
-    user_input = ""
-    option = "d 1"
-    tasks = []
-    expected = {:delete, "1"}
-    IOAssert.assert_with_input(user_input, ToDoListAppAssert.option_to_command(option, tasks, expected))
-  end
-
-  test "'e' menu option is valid" do
-    user_input = ""
-    option = "e"
-    tasks = []
-    expected = :exit
-    IOAssert.assert_with_input(user_input, ToDoListAppAssert.option_to_command(option, tasks, expected))
   end
 
   test "it can add new tasks" do
@@ -106,7 +46,7 @@ defmodule ToDoListAppTest do
     user_input = "a\nFinish Todo List\nWrite blog\n\ne"
     tasks = []
     expected_result = :ok
-    IOAssert.assert_with_input(user_input, ToDoListAppAssert.options(tasks, expected_result))
+    IOAssert.assert_with_input(user_input, ToDoListAppAssert.run(tasks, expected_result))
   end
 
   test "it can list all to do tasks", context do
@@ -114,7 +54,6 @@ defmodule ToDoListAppTest do
     command = :list_tasks
     tasks = context[:tasks]
     expected_result = {:list_tasks, [context[:task1], context[:task2], context[:task3]]}
-
     IOAssert.assert_with_input(user_input, ToDoListAppAssert.process_command(command, tasks, expected_result))
   end
 


### PR DESCRIPTION
@maikon
@jsuchy

See what you think now.
To come:
Move Command modules to commands dir and rename
Make todo.ex the 'main' module
